### PR TITLE
Update to version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install url-query-to-prisma
 
 ## Usage
 
-Here's an example of a custom formatter made with the formatter helper functions and the output it generates. By default, values of foreign relations can be accessed with dots in the key, e.g. 'blogAuthor.name'.
+Here's an example of a custom formatter made with the formatter helper functions and the output it generates. By default, values of foreign relations can be accessed with dots in the key, e.g. ```blogAuthor.name```.
 
 ```js
 import express from 'express';
@@ -29,17 +29,17 @@ const app = express();
 const prisma = new PrismaClient();
 
 const customFormatter = {
-  title: formatters.where({ filterType: 'contains', filterOptions: { mode: 'insensitive' } }),
-  author: formatters.where({ filterType: 'contains', filterOptions: { mode: 'insensitive' }, formatterOptions: { tableColName: 'owner.name' } }),
+  title: formatters.whereContains({ caseSensitive: false }),
+  author: formatters.whereContains({ caseSensitive: false, tableColName: 'owner.name' }),
   fromDate: formatters.where({ 
     filterType: 'gte', 
     valueProcessor: processors.date, 
-    formatterOptions: { tableColName: 'publishedAt' }
+    tableColName: 'publishedAt'
   }),
   toDate: formatters.where({ 
     filterType: 'lte', 
     valueProcessor: processors.date, 
-    formatterOptions: { tableColName: 'publishedAt' }
+    tableColName: 'publishedAt'
   }),
 }
 
@@ -77,13 +77,13 @@ const result = {
 }
 ```
 
-An instance of the middleware is created by calling urlQueryToPrisma as a function. It takes a customFormatter parameter and a customOptions parameter.
+An instance of the middleware is created by calling ```urlQueryToPrisma``` as a function. It takes a ```customFormatter``` parameter and a ```customOptions``` parameter.
 
 ## Custom Formatters
 
-The custom formatter is an object that tells the middleware what to do with each parameter in the url query. Each object key in the custom formatter relates to the respective url query parameter, and its corresponding value should be a function that takes four parameters: the query object, query key, value, and an options object. As the middleware runs through each formatter it will directly modify the properties on the query object, building it up into its final form.
+The custom formatter is an object that tells the middleware what to do with each parameter in the url query. Each object key in the custom formatter relates to the respective url query parameter, and its corresponding value should be a function that takes four parameters: the query object, query parameter key, query parameter value, and an options object. As the middleware runs through each formatter it will directly modify the properties on the query object, building it up into its final form.
 
-By default, the middleware will take the following url parameters and turn them into a prismaQueryParams object:
+By default, the middleware will take the following url parameters and turn them into a ```prismaQueryParams``` object:
 
 - skip
 - take
@@ -103,23 +103,52 @@ urlQueryToPrisma(customFormatter);
 
 ## Custom Options
 
-The custom options parameter is an optional parameter of type object. This object is passed to all formatter functions, so if you have some option you want to set once and use in multiple formatters, this is the place to do it. The middleware and defaultFormatter use the following properties:
+The custom options parameter is an optional parameter of type object. This object is passed to all formatter functions, so if you have some option you want to set once and use in multiple formatters, this is the place to do it. The middleware and ```defaultFormatter``` use the following properties:
 
 |Property|Purpose|
 |-|-|
-|querySource|Defaults to 'query'. This is where the middleware will look for the url query. You can change this to access any property on the req object, e.g. 'body' after a form has been submitted.|
-|pathSeparator|Defaults to '.' but can be changed to anything you want. This character is used to structure the prismaQueryParams object to allow access to fields of foreign relations.|
+|querySource|Defaults to ```query```. This is where the middleware will look for the url query. You can change this to access any property on the ```req``` object, e.g. ```body``` after a form has been submitted.|
+|pathSeparator|Defaults to ```.``` but can be changed to anything you want. This character is used to structure the ```prismaQueryParams``` object to allow access to fields of foreign relations.|
 
-## Formatters.where
+## Formatters
 
-Each formatter can be written manually but generally it is easier to use the provided where formatter, as in the above example. It takes a single parameter of type object: customOptions. Here is an explanation of the different properties that can be set on the customOptions object.
+### Where
+
+Each formatter can be written manually but generally it is easier to use the provided where formatter, as in the above example. It takes a single parameter of type object: ```customOptions```. Here is an explanation of the different properties that can be set on the customOptions object.
 
 |Property|Purpose|
 |-|-|
-|filterType|Defaults to null. A string that determines a specific prisma where filter type, e.g. 'includes', 'lte', etc.|
-|filterOptions|Defaults to an empty object. This is an object that is added onto the where filter. Useful to include { mode: 'insensitive' } on the filter, which is required to run case-insensitive string queries on PostgreSQL and MongoDB databases.|
+|filterType|Defaults to ```null```. A string that determines a specific prisma where filter type, e.g. ```includes```, ```lte```, etc.|
+|filterOptions|Defaults to an empty object. This is an object that is added onto the where filter. Useful to include ```{ mode: 'insensitive' }``` on the filter, which is required to run case-insensitive string queries on postgreSQL and mongoDB databases.|
 |valueProcessor|Defaults to a function that returns the query value in its raw form. A function that takes a value parameter and should return a value. This is for applying any processing on the value we are going to match against the database. Since a http url query or body always has string values, this is useful for turning the string into a number or a date. Import processors as shown in the usage section to get some convenient functions to do this (since typing these functions over and over gets boring).|
-|formatterOptions|Defaults to an object with a querySource of 'query' and a pathSeparator of '.'. Currently this is just to set a tableColName. By default, the where formatter will create a prismaQueryParams object which will match against a table column that has the same name as the url query parameter. By setting tableColumnName on the formatterOptions, you can match a url query parameter against a differently named table column. This is also necessary to group multiple url query parameters on a filter for a single table column.|
+|tableColName|Defaults to ```null```. By default, the where formatter will match against a table column that has the same name as the url query parameter. By setting ```tableColName```, you can match a url query parameter against a differently named table column. This is also necessary to group multiple url query parameters on a filter for a single table column.|
+
+### WhereContains
+
+This is a convenience method that wraps around the standard Where formatter function, to streamline the process of getting partial, case-insensitive string matches. It takes a ```customOptions``` parameter just like the ```where``` formatter, but this time the ```customOptions``` object can also take a property called ```caseSensitive```. Some databases are case-insensitive already so this property will not need to be set, but if you are working on postgreSQL or mongoDB and you want case-insensitive matches, you'll need to set ```caseSensitive``` to ```false```. It defaults to ```true```, but if you are working on a case-insensitive database this won't do anything.
+
+With standard ```where```:
+
+```js
+formatters.where({
+  filterType: 'contains',
+  // Required on case-sensitive dbs to facilitate case-insensitive matching. Will give errors on case-insensitive dbs.
+  filterOptions: { mode: 'insensitive' }
+})
+```
+
+You can do the equivalent more concisely with ```whereContains```:
+
+```js
+// On a db with case-sensitivity, e.g. postgreSQL or mongoDB.
+formatters.whereContains({ caseSensitive: false });
+// On a db with no case-sensitivity, e.g. mySQL.
+formatters.whereContains();
+```
+
+Doesn't look like much of a difference, but if your ```customFormatter``` has 5 of these in a row, ```whereContains``` will make it a lot cleaner.
+
+If your database is already case-insensitive, do not set ```caseSensitive: false``` as this will cause prisma to throw an error. The case sensitivity is based on a 'mode' property, but on case-insensitive databases, it is not available on the generated prisma client API.
 
 ## Processors
 
@@ -127,10 +156,12 @@ These are tiny functions for turning the url query parameter values from their d
 
 ## Writing a custom formatter
 
-If you want to write your own formatter for a query parameter without using formatters.where(), the function should look something like this:
+If you want to write your own formatter for a query parameter without using ```formatters.where()```, the function should look something like this:
 
 ```js
 const myFormatter = {
+  // The options object here is passed from urlQueryToPrisma, i.e. it was the 
+  // customOptions object passed to that when urlQueryToPrisma was instantiated.
   myQueryParam: (obj, key, value, options) => {
     obj.where = {
       ...obj.where,
@@ -140,9 +171,9 @@ const myFormatter = {
 };
 ```
 
-This is a simple function that just adds the key value pair onto the where object. However, formatters.where() uses the deepMerge package to allow for cumulative queries like in the usage example, where two different url query parameters were mapped to 'lte' and 'gte' filters on one table column. It also uses the pathToNestedObj package to allow accessing the values of foreign relations.
+This is a simple function that just adds the key value pair onto the where object. However, ```formatters.where()``` uses the deepMerge package to allow for cumulative queries like in the usage example, where two different url query parameters were mapped to ```lte``` and ```gte``` filters on one table column. It also uses the pathToNestedObj package to allow accessing the values of foreign relations.
 
-At the start of processing, an empty temp object on the prismaQueryParams object can be used if information needs to be stored from one formatting function to another, as is the case with the defaultFormatter formatters for orderBy and sortOrder. The temp object gets deleted at the end of the middleware function.
+At the start of processing, an empty temp object on the ```prismaQueryParams``` object can be used if information needs to be stored from one formatting function to another, as is the case with the ```defaultFormatter``` formatters for ```orderBy``` and ```sortOrder```. The temp object gets deleted at the end of the middleware function.
 
 ## Previous versions
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # url-query-to-prisma
 
-Middleware to turn a URL query into an object formatted to match the object shape to filter a Prisma ORM client query.
+Express middleware to turn a URL query/body into an object formatted to match the object shape to filter a Prisma ORM client query.
 
-Suitable for something like a blogs page where you want the user to be able to search for blogs by a particular user, date range or sort them into date order, etc. Generally this is only intended for pretty basic queries encoded in the URL, but you may be able to extend it with custom formatters to fit your needs. How to do so is explained below.
+Suitable for something like a blogs page where you want the user to be able to search for blogs by a particular user, date range or sort them into date order, etc.
 
 The prisma query object ends up on ```req.prismaQueryParams```. The idea is, when you eventually get to your query you can just put something like:
 
@@ -18,287 +18,132 @@ npm install url-query-to-prisma
 
 ## Usage
 
-Here's an example of a custom formatter made with the formatter helper functions and the output it generates. Values of foreign relations can be accessed with dots in the key, e.g. 'blogAuthor.name'. With formatters.where, the url query parameter name must match the table column name you are trying to compare against, although I plan to change this at a later date.
+Here's an example of a custom formatter made with the formatter helper functions and the output it generates. By default, values of foreign relations can be accessed with dots in the key, e.g. 'blogAuthor.name'.
 
 ```js
+import express from 'express';
+import { PrismaClient } from '../generated/prisma/client.js';
 import { urlQueryToPrisma, formatters, processors } from 'urlQueryToPrisma';
 
+const app = express();
+const prisma = new PrismaClient();
+
 const customFormatter = {
-  title: formatters.where('contains', { mode: 'insensitive' })
-  'author.name': formatters.where('contains', { mode: 'insensitive' })
-  fromDate: formatters.groupWhere('author.createdAt', 'gte', processors.date)
-  toDate: formatters.groupWhere('author.createdAt', 'lte', processors.date)
+  title: formatters.where({ filterType: 'contains', filterOptions: { mode: 'insensitive' } }),
+  author: formatters.where({ filterType: 'contains', filterOptions: { mode: 'insensitive' }, formatterOptions: { tableColName: 'owner.name' } }),
+  fromDate: formatters.where({ 
+    filterType: 'gte', 
+    valueProcessor: processors.date, 
+    formatterOptions: { tableColName: 'publishedAt' }
+  }),
+  toDate: formatters.where({ 
+    filterType: 'lte', 
+    valueProcessor: processors.date, 
+    formatterOptions: { tableColName: 'publishedAt' }
+  }),
 }
 
-app.use('/blogs', 
-  urlQueryToPrisma('query', customFormatter), 
+app.use(
+  '/blogs', 
+  urlQueryToPrisma(customFormatter), 
   async (req, res, next) => {
-    const blogs = await prisma.blogs.findMany(req.prismaQueryObj);
-    res.send(blogs);
+    try {
+      const blogs = await prisma.blog.findMany(req.prismaQueryParams);
+      res.send(blogs);
+    } catch (error) {
+      next(error);
+    }
 });
 
 // A request with the following url will give this result... 
-// /blogs?blogTitle=myBlog&blogAuthor.name=jimbo&authorCreatedFromDate=2020-01-01&authorCreatedToDate=2020-12-31
+// /blogs?title=myBlog&author=jimbo&fromDate=2020-01-01&toDate=2020-12-31
 const result = {
   where: {
-    title: 'myBlog',
-    author: {
+    title: {
+      contains: 'myBlog',
+      mode: 'insensitive'
+    },
+    owner: {
       name: {
         contains: 'jimbo',
         mode: 'insensitive'
       },
-      createdAt: {
-        gte: '2020-01-01', // Date object representing this date.
-        lte: '2020-12-31'  // Date object representing this date.
-      }
-    }
-  }
-}
-```
-
-An instance of the middleware is created by calling urlQueryToPrisma as a function.
-
-The first parameter defines the query source. So if the query information is on req.query, you should put 'query'. If it is on the req.body, then this should be 'body'. It defaults to 'query'.
-
-You will need to provide a customFormatter as the second parameter, to tell the middleware what query keys you want included on your prisma query, in what format and how the query values should be processed. Any query keys sent by the client which are not defined on the formatter will be ignored. This way, a bad actor will not be able to include different keys to the ones we are expecting.
-
-The customFormatter should be of type object. The middleware will match each query key to a property in the formatter object - which will contain a function - and then use that function to add that query key and value into the prisma query object in the desired format.
-
-The middleware will automatically add standard prisma stuff to the output, like take, skip, and orderBy. But it will not take any other query parameters unless explicitly told to in your custom formatter.
-
-A third parameter of customOptions can be provided for middleware-wide options. Currently the only purpose for this is to change the default pathSeparator (the thing that allows accessing foreign relations values).
-
-```js
-urlQueryToPrisma('query', myCustomFormatter, { pathSeparator: '-' });
-```
-
-At some point I will move querySource from the first parameter into the customOptions object, as the query source is probably going to be 'query' most of the time.
-
-## Examples
-
-### Mapping query params and values to the prisma query object
-
-```js
-import express from 'express';
-import { urlQueryToPrisma, formatters } from 'url-query-to-prisma';
-
-// Manually... it's a bit long, but you can alter the query object and process your value in any way you want.
-const manualFormatter = {
-  name: (obj, key, value, options) => {
-    obj.where = {
-      ...obj.where,
-      name: {
-        contains: value,
-        mode: 'insensitive'
-      }
-    }
-  },
-  age: (obj, key, value, options) => {
-    obj.where = {
-      ...obj.where,
-      age: Number(value)
-    }
-  }
-}
-
-// With the convenient where function, it is a lot cleaner,
-// although it has still ended up a bit overcomplicated, I think.
-const customFormatter = {
-  name: formatters.where('contains', { mode: 'insensitive' }),
-  age: formatters.where(null, {}, (value) => Number(value))
-}
-
-const app = express();
-app.use(urlQueryToPrisma('query', customFormatter));
-
-app.listen(8080, () => console.log('Listening on port 8080'));
-```
-
-Given a url of: ```http://localhost:8080?name=jimbo&age=23```, the req.prismaQueryParams will end up in the following format:
-
-```js
-req.prismaQueryParams = {
-  where: {
-    name: {
-      contains: 'jimbo',
-      mode: 'insensitive'
     },
-    age: 23
-  }
-};
-```
-
-### Writing a custom formatter
-
-Every formatter function is called with the prismaQueryParams object, the key (i.e. the name of the query parameter in the URL), and its value, and an options object (the user can add custom options upon instantiating an instance of the urlQueryToPrisma middleware, for example to use different path separators). The prismaQueryParams object is directly modified by each formatter function, to gradually build up the final query object. The spread syntax (...obj.where) is used to stop existing object properties from being deleted.
-
-The default formatters use the pathToQueryObj package to turn a path separated by a special character (by default, a dot) into a nested object, which can be used to access the columns of foreign relations. For example, if a blog has a foreign relation of an owner, you could access any of the owner's values by using 'owner.name', as the key, for instance. You can also use pathToQueryObj in your custom formatters in the same manner.
-
-The special character can be changed from the default '.' by supplying a 'pathSeparator' property on the customOptions object when urlQueryToPrisma is instantiated.
-
-```js
-const myCustomFormatter = {
-  // myOptions passed from urlQueryToPrisma to this function!
-  myUrlParam: (obj, key, value, options) => {
-    obj.where ={
-      ...obj.where,
-      ...pathToNestedObj('owner-name', options.pathSeparator, value)
+    publishedAt: {
+      gte: '2020-01-01', // Date object representing this date.
+      lte: '2020-12-31'  // Date object representing this date.
     }
   }
 }
-
-const myOptions = {
-  pathSeparator: '-'
-}
-
-app.use(urlQueryToPrisma('query', myCustomFormatter, myOptions))
 ```
 
-```js
-import express from 'express';
-import { urlQueryToPrisma } from 'url-query-to-prisma';
+An instance of the middleware is created by calling urlQueryToPrisma as a function. It takes a customFormatter parameter and a customOptions parameter.
 
+## Custom Formatters
+
+The custom formatter is an object that tells the middleware what to do with each parameter in the url query. Each object key in the custom formatter relates to the respective url query parameter, and its corresponding value should be a function that takes four parameters: the query object, query key, value, and an options object. As the middleware runs through each formatter it will directly modify the properties on the query object, building it up into its final form.
+
+By default, the middleware will take the following url parameters and turn them into a prismaQueryParams object:
+
+- skip
+- take
+- cursor
+- orderBy
+- sortOrder
+
+If you want to change any of these behaviours, you can define your own in your custom formatter which will overwrite the defaults. If you want one of the default parameters to be ignored, assign null to it instead of a function.
+
+```js
 const customFormatter = {
-  // Where author contains value - case-insensitive partial match.
-  author: (obj, key, value, options) => {
+  cursor: null
+}
+
+urlQueryToPrisma(customFormatter);
+```
+
+## Custom Options
+
+The custom options parameter is an optional parameter of type object. This object is passed to all formatter functions, so if you have some option you want to set once and use in multiple formatters, this is the place to do it. The middleware and defaultFormatter use the following properties:
+
+|Property|Purpose|
+|-|-|
+|querySource|Defaults to 'query'. This is where the middleware will look for the url query. You can change this to access any property on the req object, e.g. 'body' after a form has been submitted.|
+|pathSeparator|Defaults to '.' but can be changed to anything you want. This character is used to structure the prismaQueryParams object to allow access to fields of foreign relations.|
+
+## Formatters.where
+
+Each formatter can be written manually but generally it is easier to use the provided where formatter, as in the above example. It takes a single parameter of type object: customOptions. Here is an explanation of the different properties that can be set on the customOptions object.
+
+|Property|Purpose|
+|-|-|
+|filterType|Defaults to null. A string that determines a specific prisma where filter type, e.g. 'includes', 'lte', etc.|
+|filterOptions|Defaults to an empty object. This is an object that is added onto the where filter. Useful to include { mode: 'insensitive' } on the filter, which is required to run case-insensitive string queries on PostgreSQL and MongoDB databases.|
+|valueProcessor|Defaults to a function that returns the query value in its raw form. A function that takes a value parameter and should return a value. This is for applying any processing on the value we are going to match against the database. Since a http url query or body always has string values, this is useful for turning the string into a number or a date. Import processors as shown in the usage section to get some convenient functions to do this (since typing these functions over and over gets boring).|
+|formatterOptions|Defaults to an object with a querySource of 'query' and a pathSeparator of '.'. Currently this is just to set a tableColName. By default, the where formatter will create a prismaQueryParams object which will match against a table column that has the same name as the url query parameter. By setting tableColumnName on the formatterOptions, you can match a url query parameter against a differently named table column. This is also necessary to group multiple url query parameters on a filter for a single table column.|
+
+## Processors
+
+These are tiny functions for turning the url query parameter values from their default strings into other kinds of data. Added purely for convenience since writing stuff like ```(value) => new Date(value)``` for various formatters gets old quickly.
+
+## Writing a custom formatter
+
+If you want to write your own formatter for a query parameter without using formatters.where(), the function should look something like this:
+
+```js
+const myFormatter = {
+  myQueryParam: (obj, key, value, options) => {
     obj.where = {
       ...obj.where,
-      [key]: {
-        contains: value,
-        mode: 'insensitive'
-      }
-    }
+      [key]: value,
+    };
   },
-  // Where startDate is greater than or equal to value.
-  startDate: (obj, key, value, options) => {
-    obj.where = {
-      ...obj.where,
-      startDate: {
-        gte: new Date(value)
-      }
-    }
-  },
-  // Where endDate is less than or equal to value.
-  endDate: (obj, key, value, options) => {
-    obj.where = {
-      ...obj.where,
-      endDate: {
-        lte: new Date(value)
-      }
-    }
-  }
-};
-
-const app = express();
-app.use(urlQueryToPrisma('query', customFormatter));
-app.listen(8080, () => console.log('Listening on port 8080'));
-```
-
-Given a url of: ```http://localhost:8080?author=billy&startDate=2025-01-01&endDate=2025-02-28```, the req.prismaQueryParams will end up in the following format:
-
-```js
-req.prismaQueryParams = {
-  where: {
-    author: {
-      contains: 'billy'
-    }
-    startDate: {
-      gte: '2025-01-01' // Date obj representing this date.
-    },
-    endDate: {
-      lte: '2025-02-28' // Date obj representing this date.
-    }
-  }
 };
 ```
 
-### Using formatter functions to easily create a customFormatter
+This is a simple function that just adds the key value pair onto the where object. However, formatters.where() uses the deepMerge package to allow for cumulative queries like in the usage example, where two different url query parameters were mapped to 'lte' and 'gte' filters on one table column. It also uses the pathToNestedObj package to allow accessing the values of foreign relations.
 
-#### Where
+At the start of processing, an empty temp object on the prismaQueryParams object can be used if information needs to be stored from one formatting function to another, as is the case with the defaultFormatter formatters for orderBy and sortOrder. The temp object gets deleted at the end of the middleware function.
 
-Instead of creating your own functions as in the above example, you can use the where formatter function as below.
+## Previous versions
 
-```js
-import { urlQueryToPrisma, formatters } from 'url-to-prisma-query';
-
-// Blah blah express setup
-
-const customFormatter = {
-  author: formatters.where('contains', { mode: 'insensitive' });
-  startDate: formatters.where('gte'),
-  endDate: formatters.where('lte')
-};
-
-app.use(urlQueryToPrisma('query', customFormatter));
-```
-
-The where function can take a filterType (i.e. 'contains', 'lte', 'gt', 'not'), an options object and a valueFormatter parameter which is a function that will process the value before adding it into the prismaQueryParams object. For example, turning a string into a date.
-
-If the filterType is null, the query key and value will just be added to the base where object.
-
-```js
-formatters.where('lte', {}, (value) => new Date(value));
-```
-
-There are also some convenience methods on the processors object that can make this a bit less annoying to type.
-
-```js
-const { urlQueryToPrisma, formatters, processors } = require('url-query-to-prisma');
-
-formatters.where('lte', {}, processors.date);
-```
-
-#### Group where
-
-There is also a formatter function for grouping input query parameters and combining them into one object property. An example of where this might be useful is combining a fromDate and a toDate to get all database table entries with a publishedAt date between the two.
-
-The groupWhere function can take a groupKey (the name of the whole group, i.e. the name of the db table column you want to match against), a key ('gte', 'lte', etc.) and a valueFormatter function for doing any necessary processing to the value before adding it onto the prismaQueryParams object.
-
-```js
-import { urlQueryToPrisma, formatters, processors } from 'url-to-prisma-query';
-
-// Blah blah express setup
-
-// An optional function is given to the groupWhere function to apply any required processing to the
-// values assigned to gte and lte. In this case the url query param string will get turned into a date.
-const customFormatter = {
-  fromDate: formatters.groupWhere('publishedAt', 'gte', processors.date),
-  toDate: formatters.groupWhere('publishedAt', 'lte', processors.date)
-}
-
-app.use(urlQueryToPrisma('query', customFormatter));
-
-// Resulting object when given a query string of ?fromDate=2025-01-01&toDate=2025-12-31
-const prismaQueryParams = {
-  publishedAt: {
-    gte: '2025-01-01' // Date object representing this date.
-    lte: '2025-12-31' // Date object representing this date.
-  }
-}
-```
-
-## Default behaviour
-
-Using all the included supported query parameters will result in an object in the following format (with example values):
-
-```js
-const prismaQueryParams = {
-  skip: 5,
-  take: 5,
-  cursor: 5,
-  // Can have multiple orderBy and sortOrder query parameters. 
-  orderBy: {
-    // 'asc' is default, but sortOrder can be a parameter to choose between 'asc' or 'desc'.
-    author: 'asc',
-    publishedDate: 'desc'
-  }
-}
-```
-
-If you want any of these to be excluded, you can do so by putting a null function for that query key on your customFormatter:
-
-```js
-app.use(urlQueryToPrisma('query', {
-  cursor: null,
-}))
-```
+Docs for v1 are in docs/README_v1.md.

--- a/defaultFormatter.js
+++ b/defaultFormatter.js
@@ -8,14 +8,14 @@ const defaultFormatter = {
   take: (queryObj, key, value) => (queryObj.take = Number(value)),
   skip: (queryObj, key, value) => (queryObj.skip = Number(value)),
   cursor: (queryObj, key, value) => (queryObj.cursor = { id: Number(value) }),
-  orderBy: (queryObj, key, value) => {
+  orderBy: (queryObj, key, value, options) => {
     // Works with string and arrays of strings, and paths like you would use with sql, e.g. owner.name.
     if (Array.isArray(value)) {
       queryObj.orderBy = {};
       value.forEach((e) => {
         queryObj.orderBy = deepMerge(
           queryObj.orderBy,
-          pathToNestedObj(e, '.', 'asc'),
+          pathToNestedObj(e, options.pathSeparator, 'asc'),
         );
         // Save keys to an array for use in sortOrder later. In sortOrder function,
         // an updated version of the orderBy obj value will be constructed out of the
@@ -24,11 +24,11 @@ const defaultFormatter = {
         queryObj.temp.orderByPaths = orderByPaths ? [...orderByPaths, e] : [e];
       });
     } else {
-      queryObj.orderBy = pathToNestedObj(value, '.', 'asc');
+      queryObj.orderBy = pathToNestedObj(value, options.pathSeparator, 'asc');
       queryObj.temp.orderByPaths = [value];
     }
   },
-  sortOrder: (queryObj, key, value) => {
+  sortOrder: (queryObj, key, value, options) => {
     // Works with string and arrays of strings.
     // Assumes the first key in orderByKeys corresponds to the first value in sortOrder.
     const orderByPaths = queryObj.temp.orderByPaths;
@@ -36,7 +36,7 @@ const defaultFormatter = {
       value.forEach((e) => {
         const savedPath = orderByPaths?.shift();
         if (savedPath) {
-          const mega = pathToNestedObj(savedPath, '.', e);
+          const mega = pathToNestedObj(savedPath, options.pathSeparator, e);
           queryObj.orderBy = {
             ...queryObj.orderBy,
             ...mega,
@@ -46,7 +46,7 @@ const defaultFormatter = {
     } else {
       const savedPath = orderByPaths?.shift();
       if (savedPath) {
-        const obj = pathToNestedObj(savedPath, '.', value);
+        const obj = pathToNestedObj(savedPath, options.pathSeparator, value);
         queryObj.orderBy = {
           ...queryObj.orderBy,
           ...obj,

--- a/defaultFormatter.js
+++ b/defaultFormatter.js
@@ -54,14 +54,6 @@ const defaultFormatter = {
       }
     }
   },
-  where: (queryObj, key, value) => {
-    // This is the default function that will be used. If no other formatter function is used, this one will.
-    // User can overwrite with a custom function that puts all conditions in 'includes', for instance.
-    queryObj.where = {
-      ...queryObj.where,
-      [key]: value,
-    };
-  },
   setup: () => {
     // For setup user may want to do in prep for their custom formatter functions.
     return;

--- a/defaultFormatter.test.js
+++ b/defaultFormatter.test.js
@@ -95,7 +95,7 @@ describe('defaultFormatter', () => {
         author: 'billy',
       },
     });
-    const middleware = urlQueryToPrisma('query', {
+    const middleware = urlQueryToPrisma({
       author: (obj, key, value) => {
         obj.where = {
           ...obj.where,

--- a/defaultFormatter.test.js
+++ b/defaultFormatter.test.js
@@ -250,4 +250,24 @@ describe('defaultFormatter', () => {
       },
     });
   });
+
+  it('orderBy and sortOrder should use the path separator on the options', () => {
+    const req = httpMocks.createRequest({
+      ...basicRequest,
+      query: {
+        orderBy: ['owner/name', 'publishedAt'],
+        sortOrder: ['desc', 'asc'],
+      },
+    });
+    const middleware = urlQueryToPrisma({}, { pathSeparator: '/' });
+    middleware(req, res, next);
+    expect(req.prismaQueryParams).toEqual({
+      orderBy: {
+        owner: {
+          name: 'desc',
+        },
+        publishedAt: 'asc',
+      },
+    });
+  });
 });

--- a/docs/README_v1.md
+++ b/docs/README_v1.md
@@ -1,0 +1,304 @@
+# url-query-to-prisma
+
+Middleware to turn a URL query into an object formatted to match the object shape to filter a Prisma ORM client query.
+
+Suitable for something like a blogs page where you want the user to be able to search for blogs by a particular user, date range or sort them into date order, etc. Generally this is only intended for pretty basic queries encoded in the URL, but you may be able to extend it with custom formatters to fit your needs. How to do so is explained below.
+
+The prisma query object ends up on ```req.prismaQueryParams```. The idea is, when you eventually get to your query you can just put something like:
+
+```js
+prismaClient.modelName.find(req.prismaQueryParams)
+```
+
+## Install
+
+```bash
+npm install url-query-to-prisma
+```
+
+## Usage
+
+Here's an example of a custom formatter made with the formatter helper functions and the output it generates. Values of foreign relations can be accessed with dots in the key, e.g. 'blogAuthor.name'. With formatters.where, the url query parameter name must match the table column name you are trying to compare against, although I plan to change this at a later date.
+
+```js
+import { urlQueryToPrisma, formatters, processors } from 'urlQueryToPrisma';
+
+const customFormatter = {
+  title: formatters.where('contains', { mode: 'insensitive' })
+  'author.name': formatters.where('contains', { mode: 'insensitive' })
+  fromDate: formatters.groupWhere('author.createdAt', 'gte', processors.date)
+  toDate: formatters.groupWhere('author.createdAt', 'lte', processors.date)
+}
+
+app.use('/blogs', 
+  urlQueryToPrisma('query', customFormatter), 
+  async (req, res, next) => {
+    const blogs = await prisma.blogs.findMany(req.prismaQueryObj);
+    res.send(blogs);
+});
+
+// A request with the following url will give this result... 
+// /blogs?blogTitle=myBlog&blogAuthor.name=jimbo&authorCreatedFromDate=2020-01-01&authorCreatedToDate=2020-12-31
+const result = {
+  where: {
+    title: 'myBlog',
+    author: {
+      name: {
+        contains: 'jimbo',
+        mode: 'insensitive'
+      },
+      createdAt: {
+        gte: '2020-01-01', // Date object representing this date.
+        lte: '2020-12-31'  // Date object representing this date.
+      }
+    }
+  }
+}
+```
+
+An instance of the middleware is created by calling urlQueryToPrisma as a function.
+
+The first parameter defines the query source. So if the query information is on req.query, you should put 'query'. If it is on the req.body, then this should be 'body'. It defaults to 'query'.
+
+You will need to provide a customFormatter as the second parameter, to tell the middleware what query keys you want included on your prisma query, in what format and how the query values should be processed. Any query keys sent by the client which are not defined on the formatter will be ignored. This way, a bad actor will not be able to include different keys to the ones we are expecting.
+
+The customFormatter should be of type object. The middleware will match each query key to a property in the formatter object - which will contain a function - and then use that function to add that query key and value into the prisma query object in the desired format.
+
+The middleware will automatically add standard prisma stuff to the output, like take, skip, and orderBy. But it will not take any other query parameters unless explicitly told to in your custom formatter.
+
+A third parameter of customOptions can be provided for middleware-wide options. Currently the only purpose for this is to change the default pathSeparator (the thing that allows accessing foreign relations values).
+
+```js
+urlQueryToPrisma('query', myCustomFormatter, { pathSeparator: '-' });
+```
+
+At some point I will move querySource from the first parameter into the customOptions object, as the query source is probably going to be 'query' most of the time.
+
+## Examples
+
+### Mapping query params and values to the prisma query object
+
+```js
+import express from 'express';
+import { urlQueryToPrisma, formatters } from 'url-query-to-prisma';
+
+// Manually... it's a bit long, but you can alter the query object and process your value in any way you want.
+const manualFormatter = {
+  name: (obj, key, value, options) => {
+    obj.where = {
+      ...obj.where,
+      name: {
+        contains: value,
+        mode: 'insensitive'
+      }
+    }
+  },
+  age: (obj, key, value, options) => {
+    obj.where = {
+      ...obj.where,
+      age: Number(value)
+    }
+  }
+}
+
+// With the convenient where function, it is a lot cleaner,
+// although it has still ended up a bit overcomplicated, I think.
+const customFormatter = {
+  name: formatters.where('contains', { mode: 'insensitive' }),
+  age: formatters.where(null, {}, (value) => Number(value))
+}
+
+const app = express();
+app.use(urlQueryToPrisma('query', customFormatter));
+
+app.listen(8080, () => console.log('Listening on port 8080'));
+```
+
+Given a url of: ```http://localhost:8080?name=jimbo&age=23```, the req.prismaQueryParams will end up in the following format:
+
+```js
+req.prismaQueryParams = {
+  where: {
+    name: {
+      contains: 'jimbo',
+      mode: 'insensitive'
+    },
+    age: 23
+  }
+};
+```
+
+### Writing a custom formatter
+
+Every formatter function is called with the prismaQueryParams object, the key (i.e. the name of the query parameter in the URL), and its value, and an options object (the user can add custom options upon instantiating an instance of the urlQueryToPrisma middleware, for example to use different path separators). The prismaQueryParams object is directly modified by each formatter function, to gradually build up the final query object. The spread syntax (...obj.where) is used to stop existing object properties from being deleted.
+
+The default formatters use the pathToQueryObj package to turn a path separated by a special character (by default, a dot) into a nested object, which can be used to access the columns of foreign relations. For example, if a blog has a foreign relation of an owner, you could access any of the owner's values by using 'owner.name', as the key, for instance. You can also use pathToQueryObj in your custom formatters in the same manner.
+
+The special character can be changed from the default '.' by supplying a 'pathSeparator' property on the customOptions object when urlQueryToPrisma is instantiated.
+
+```js
+const myCustomFormatter = {
+  // myOptions passed from urlQueryToPrisma to this function!
+  myUrlParam: (obj, key, value, options) => {
+    obj.where ={
+      ...obj.where,
+      ...pathToNestedObj('owner-name', options.pathSeparator, value)
+    }
+  }
+}
+
+const myOptions = {
+  pathSeparator: '-'
+}
+
+app.use(urlQueryToPrisma('query', myCustomFormatter, myOptions))
+```
+
+```js
+import express from 'express';
+import { urlQueryToPrisma } from 'url-query-to-prisma';
+
+const customFormatter = {
+  // Where author contains value - case-insensitive partial match.
+  author: (obj, key, value, options) => {
+    obj.where = {
+      ...obj.where,
+      [key]: {
+        contains: value,
+        mode: 'insensitive'
+      }
+    }
+  },
+  // Where startDate is greater than or equal to value.
+  startDate: (obj, key, value, options) => {
+    obj.where = {
+      ...obj.where,
+      startDate: {
+        gte: new Date(value)
+      }
+    }
+  },
+  // Where endDate is less than or equal to value.
+  endDate: (obj, key, value, options) => {
+    obj.where = {
+      ...obj.where,
+      endDate: {
+        lte: new Date(value)
+      }
+    }
+  }
+};
+
+const app = express();
+app.use(urlQueryToPrisma('query', customFormatter));
+app.listen(8080, () => console.log('Listening on port 8080'));
+```
+
+Given a url of: ```http://localhost:8080?author=billy&startDate=2025-01-01&endDate=2025-02-28```, the req.prismaQueryParams will end up in the following format:
+
+```js
+req.prismaQueryParams = {
+  where: {
+    author: {
+      contains: 'billy'
+    }
+    startDate: {
+      gte: '2025-01-01' // Date obj representing this date.
+    },
+    endDate: {
+      lte: '2025-02-28' // Date obj representing this date.
+    }
+  }
+};
+```
+
+### Using formatter functions to easily create a customFormatter
+
+#### Where
+
+Instead of creating your own functions as in the above example, you can use the where formatter function as below.
+
+```js
+import { urlQueryToPrisma, formatters } from 'url-to-prisma-query';
+
+// Blah blah express setup
+
+const customFormatter = {
+  author: formatters.where('contains', { mode: 'insensitive' });
+  startDate: formatters.where('gte'),
+  endDate: formatters.where('lte')
+};
+
+app.use(urlQueryToPrisma('query', customFormatter));
+```
+
+The where function can take a filterType (i.e. 'contains', 'lte', 'gt', 'not'), an options object and a valueFormatter parameter which is a function that will process the value before adding it into the prismaQueryParams object. For example, turning a string into a date.
+
+If the filterType is null, the query key and value will just be added to the base where object.
+
+```js
+formatters.where('lte', {}, (value) => new Date(value));
+```
+
+There are also some convenience methods on the processors object that can make this a bit less annoying to type.
+
+```js
+const { urlQueryToPrisma, formatters, processors } = require('url-query-to-prisma');
+
+formatters.where('lte', {}, processors.date);
+```
+
+#### Group where
+
+There is also a formatter function for grouping input query parameters and combining them into one object property. An example of where this might be useful is combining a fromDate and a toDate to get all database table entries with a publishedAt date between the two.
+
+The groupWhere function can take a groupKey (the name of the whole group, i.e. the name of the db table column you want to match against), a key ('gte', 'lte', etc.) and a valueFormatter function for doing any necessary processing to the value before adding it onto the prismaQueryParams object.
+
+```js
+import { urlQueryToPrisma, formatters, processors } from 'url-to-prisma-query';
+
+// Blah blah express setup
+
+// An optional function is given to the groupWhere function to apply any required processing to the
+// values assigned to gte and lte. In this case the url query param string will get turned into a date.
+const customFormatter = {
+  fromDate: formatters.groupWhere('publishedAt', 'gte', processors.date),
+  toDate: formatters.groupWhere('publishedAt', 'lte', processors.date)
+}
+
+app.use(urlQueryToPrisma('query', customFormatter));
+
+// Resulting object when given a query string of ?fromDate=2025-01-01&toDate=2025-12-31
+const prismaQueryParams = {
+  publishedAt: {
+    gte: '2025-01-01' // Date object representing this date.
+    lte: '2025-12-31' // Date object representing this date.
+  }
+}
+```
+
+## Default behaviour
+
+Using all the included supported query parameters will result in an object in the following format (with example values):
+
+```js
+const prismaQueryParams = {
+  skip: 5,
+  take: 5,
+  cursor: 5,
+  // Can have multiple orderBy and sortOrder query parameters. 
+  orderBy: {
+    // 'asc' is default, but sortOrder can be a parameter to choose between 'asc' or 'desc'.
+    author: 'asc',
+    publishedDate: 'desc'
+  }
+}
+```
+
+If you want any of these to be excluded, you can do so by putting a null function for that query key on your customFormatter:
+
+```js
+app.use(urlQueryToPrisma('query', {
+  cursor: null,
+}))
+```

--- a/formatters.js
+++ b/formatters.js
@@ -51,19 +51,6 @@ function where(customOptions = {}) {
   }
 }
 
-function groupWhere(groupKey, key, valueProcessor = (value) => value) {
-  // inputQueryParam is not used - we want the value to relate to the groupKey, not the req.query input param.
-  return (queryObj, inputQueryParam, value, options) => {
-    queryObj.where = deepMerge(
-      queryObj.where,
-      pathToNestedObj(groupKey, options.pathSeparator, {
-        [key]: valueProcessor(value),
-      }),
-    );
-  };
-}
-
 module.exports = {
   where,
-  groupWhere,
 };

--- a/formatters.js
+++ b/formatters.js
@@ -8,14 +8,14 @@ const pathToNestedObj = require('path-to-nested-obj');
 // All query values are strings by default but prisma will expect real numbers
 // and date objects for making comparisons to db table values. So you can use
 // the valueProcessor to turn the string into a number, or a date, etc.
-const defaultOptions = {
-  filterType: null,
-  filterOptions: {},
-  valueProcessor: (value) => value,
-  formatterOptions: {},
-};
-
 function where(customOptions = {}) {
+  const defaultOptions = {
+    filterType: null,
+    filterOptions: {},
+    valueProcessor: (value) => value,
+    formatterOptions: {},
+  };
+
   const options = {
     ...defaultOptions,
     ...customOptions,

--- a/formatters.js
+++ b/formatters.js
@@ -51,6 +51,37 @@ function where(customOptions = {}) {
   }
 }
 
+function whereContains(customOptions = {}) {
+  const defaultOptions = {
+    // Some dbs are not case sensitive, in which case this will do nothing.
+    caseSensitive: true,
+  };
+
+  const options = {
+    ...defaultOptions,
+    ...customOptions,
+  };
+  const { caseSensitive, ...rest } = options;
+
+  // When prisma client is generated for certain db types, which are case-insensitive by design,
+  // using the mode property will throw an error. Therefore, whereContains will default to not using
+  // mode. This means this function will run case-sensitive queries on postgreSQL and mongoDB dbs,
+  // unless caseSensitive is set to false, in which case the mode object will be included in the
+  // prismaQueryObj.
+  const modeOptions = {};
+  if (!caseSensitive) modeOptions.mode = 'insensitive';
+
+  return where({
+    ...rest,
+    filterType: 'contains',
+    filterOptions: {
+      ...rest.filterOptions,
+      ...modeOptions,
+    },
+  });
+}
+
 module.exports = {
   where,
+  whereContains,
 };

--- a/formatters.js
+++ b/formatters.js
@@ -13,28 +13,23 @@ function where(customOptions = {}) {
     filterType: null,
     filterOptions: {},
     valueProcessor: (value) => value,
-    formatterOptions: {},
+    tableColName: null,
   };
 
   const options = {
     ...defaultOptions,
     ...customOptions,
   };
-  const { filterType, filterOptions, valueProcessor, formatterOptions } =
-    options;
+  const { filterType, filterOptions, valueProcessor, tableColName } = options;
 
   if (filterType) {
     return (queryObj, key, value, options) => {
       queryObj.where = deepMerge(
         queryObj.where,
-        pathToNestedObj(
-          formatterOptions.tableColName || key,
-          options.pathSeparator,
-          {
-            [filterType]: valueProcessor(value),
-            ...filterOptions,
-          },
-        ),
+        pathToNestedObj(tableColName || key, options.pathSeparator, {
+          [filterType]: valueProcessor(value),
+          ...filterOptions,
+        }),
       );
     };
   } else {
@@ -42,7 +37,7 @@ function where(customOptions = {}) {
       queryObj.where = deepMerge(
         queryObj.where,
         pathToNestedObj(
-          formatterOptions.tableColName || key,
+          tableColName || key,
           options.pathSeparator,
           valueProcessor(value),
         ),

--- a/formatters.js
+++ b/formatters.js
@@ -25,9 +25,9 @@ function where(customOptions = {}) {
 
   if (filterType) {
     return (queryObj, key, value, options) => {
-      queryObj.where = {
-        ...queryObj.where,
-        ...pathToNestedObj(
+      queryObj.where = deepMerge(
+        queryObj.where,
+        pathToNestedObj(
           formatterOptions.tableColName || key,
           options.pathSeparator,
           {
@@ -35,18 +35,18 @@ function where(customOptions = {}) {
             ...filterOptions,
           },
         ),
-      };
+      );
     };
   } else {
     return (queryObj, key, value, options) => {
-      queryObj.where = {
-        ...queryObj.where,
-        ...pathToNestedObj(
+      queryObj.where = deepMerge(
+        queryObj.where,
+        pathToNestedObj(
           formatterOptions.tableColName || key,
           options.pathSeparator,
           valueProcessor(value),
         ),
-      };
+      );
     };
   }
 }

--- a/formatters.js
+++ b/formatters.js
@@ -2,26 +2,35 @@ const deepMerge = require('@rubicon2/deep-merge');
 const pathToNestedObj = require('path-to-nested-obj');
 
 // Helper functions for customizing with customFormatter parameter.
-// Options on the text is basically just to allow mode: 'insensitive',
+// filterOptions is basically just to allow mode: 'insensitive',
 // which is required on postgreSQL or mongoDB to case-insensitive filtering.
 // valueProcessor is a function that can be used to transform the query value.
 // All query values are strings by default but prisma will expect real numbers
 // and date objects for making comparisons to db table values. So you can use
 // the valueProcessor to turn the string into a number, or a date, etc.
-function where(
-  filterType,
-  filterOptions = {},
-  valueProcessor = (value) => value,
-  formatterOptions = {},
-) {
+const defaultOptions = {
+  filterType: null,
+  filterOptions: {},
+  valueProcessor: (value) => value,
+  formatterOptions: {},
+};
+
+function where(customOptions = {}) {
+  const options = {
+    ...defaultOptions,
+    ...customOptions,
+  };
+  const { filterType, filterOptions, valueProcessor, formatterOptions } =
+    options;
+
   if (filterType) {
     return (queryObj, key, value, options) => {
-      const newKey = formatterOptions.tableColName
+      const tableColName = formatterOptions.tableColName
         ? formatterOptions.tableColName
         : key;
       queryObj.where = {
         ...queryObj.where,
-        ...pathToNestedObj(newKey, options.pathSeparator, {
+        ...pathToNestedObj(tableColName, options.pathSeparator, {
           [filterType]: valueProcessor(value),
           ...filterOptions,
         }),
@@ -29,13 +38,13 @@ function where(
     };
   } else {
     return (queryObj, key, value, options) => {
-      const newKey = formatterOptions.tableColName
+      const tableColName = formatterOptions.tableColName
         ? formatterOptions.tableColName
         : key;
       queryObj.where = {
         ...queryObj.where,
         ...pathToNestedObj(
-          newKey,
+          tableColName,
           options.pathSeparator,
           valueProcessor(value),
         ),

--- a/formatters.js
+++ b/formatters.js
@@ -25,26 +25,24 @@ function where(customOptions = {}) {
 
   if (filterType) {
     return (queryObj, key, value, options) => {
-      const tableColName = formatterOptions.tableColName
-        ? formatterOptions.tableColName
-        : key;
       queryObj.where = {
         ...queryObj.where,
-        ...pathToNestedObj(tableColName, options.pathSeparator, {
-          [filterType]: valueProcessor(value),
-          ...filterOptions,
-        }),
+        ...pathToNestedObj(
+          formatterOptions.tableColName || key,
+          options.pathSeparator,
+          {
+            [filterType]: valueProcessor(value),
+            ...filterOptions,
+          },
+        ),
       };
     };
   } else {
     return (queryObj, key, value, options) => {
-      const tableColName = formatterOptions.tableColName
-        ? formatterOptions.tableColName
-        : key;
       queryObj.where = {
         ...queryObj.where,
         ...pathToNestedObj(
-          tableColName,
+          formatterOptions.tableColName || key,
           options.pathSeparator,
           valueProcessor(value),
         ),

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -222,3 +222,80 @@ describe('where', () => {
     });
   });
 });
+
+describe('whereContains', () => {
+  it('should default to creating an object structure without a mode property', () => {
+    const partialMatcher = formatters.whereContains();
+    partialMatcher(queryObj, 'myKey', 'myValue', options);
+    expect(queryObj).toEqual({
+      where: {
+        myKey: {
+          contains: 'myValue',
+        },
+      },
+    });
+  });
+
+  it('should use mode: insensitive when caseSensitive customOptions property set to false', () => {
+    const sensitive = formatters.whereContains({ caseSensitive: false });
+    sensitive(queryObj, 'myKey', 'myValue', options);
+    expect(queryObj).toEqual({
+      where: {
+        myKey: {
+          contains: 'myValue',
+          mode: 'insensitive',
+        },
+      },
+    });
+  });
+
+  it('should ignore filterType on customsOption parameter', () => {
+    const partialMatcher = formatters.whereContains({
+      caseSensitive: false,
+      filterType: 'lte',
+    });
+    partialMatcher(queryObj, 'myKey', 'myValue', options);
+    expect(queryObj).toEqual({
+      where: {
+        myKey: {
+          contains: 'myValue',
+          mode: 'insensitive',
+        },
+      },
+    });
+  });
+
+  it('should overwrite default options with any other customsOption properties if provided', () => {
+    const partialMatcher = formatters.whereContains({
+      caseSensitive: false,
+      formatterOptions: { tableColName: 'name' },
+      filterOptions: { myCustomThing: 'whatever' },
+    });
+    partialMatcher(queryObj, 'myKey', 'myValue', options);
+    expect(queryObj).toEqual({
+      where: {
+        name: {
+          contains: 'myValue',
+          mode: 'insensitive',
+          myCustomThing: 'whatever',
+        },
+      },
+    });
+  });
+
+  it('should work with nested paths', () => {
+    const partialMatcher = formatters.whereContains({
+      formatterOptions: { tableColName: 'owner.name' },
+    });
+    partialMatcher(queryObj, 'myKey', 'myValue', options);
+    expect(queryObj).toEqual({
+      where: {
+        owner: {
+          name: {
+            contains: 'myValue',
+          },
+        },
+      },
+    });
+  });
+});

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -21,17 +21,21 @@ test.each(
 
 describe('where', () => {
   it('should add options into its results if present in parameters', () => {
-    const middleware = formatters.where('contains', {
-      someOption: 'someOptionValue',
+    const middleware = formatters.where({
+      filterType: 'contains',
+      filterOptions: {
+        someOption: 'someOptionValue',
+      },
     });
     middleware(queryObj, 'someKey', 'someValue', options);
     expect(queryObj.where.someKey.someOption).toEqual('someOptionValue');
   });
 
   it('should process the value with the valueFormatter parameter, if supplied', () => {
-    const middleware = formatters.where('contains', {}, (value) =>
-      value.toUpperCase(),
-    );
+    const middleware = formatters.where({
+      filterType: 'contains',
+      valueProcessor: (value) => value.toUpperCase(),
+    });
     middleware(queryObj, 'someDate', 'bananas', options);
     expect(queryObj).toEqual({
       where: {
@@ -43,7 +47,9 @@ describe('where', () => {
   });
 
   it('should add the query param to the base where object if filterType is null, and ignore options', () => {
-    const middleware = formatters.where(null, { someOption: 'ignoreMe' });
+    const middleware = formatters.where({
+      filterOptions: { someOption: 'ignoreMe' },
+    });
     middleware(queryObj, 'basicWhere', 'basicValue', options);
     expect(queryObj).toEqual({
       where: {
@@ -59,14 +65,14 @@ describe('where', () => {
   ])(
     'should modify the type of where to reflect the first parameter of $type',
     ({ whereType }) => {
-      const middleware = formatters.where(whereType);
+      const middleware = formatters.where({ filterType: whereType });
       middleware(queryObj, 'someKey', 'someValue', options);
       expect(queryObj.where.someKey).toEqual({ [whereType]: 'someValue' });
     },
   );
 
   it('should create a correctly nested object for accessing the table columns of a foreign relation', () => {
-    const middleware = formatters.where(null, {});
+    const middleware = formatters.where();
     middleware(queryObj, 'blogOwner.name', 'jimmy', options);
     expect(queryObj).toEqual({
       where: {
@@ -78,17 +84,19 @@ describe('where', () => {
   });
 
   it('should add options into nested object results if present in parameters', () => {
-    const middleware = formatters.where('contains', {
-      someOption: 'someOptionValue',
+    const middleware = formatters.where({
+      filterType: 'contains',
+      filterOptions: { someOption: 'someOptionValue' },
     });
     middleware(queryObj, 'one.two', 'someValue', options);
     expect(queryObj.where.one.two.someOption).toEqual('someOptionValue');
   });
 
   it('should process the value inside a nested object with the valueFormatter parameter, if supplied', () => {
-    const middleware = formatters.where('contains', {}, (value) =>
-      value.toUpperCase(),
-    );
+    const middleware = formatters.where({
+      filterType: 'contains',
+      valueProcessor: (value) => value.toUpperCase(),
+    });
     middleware(queryObj, 'fridge.shelf', 'bananas', options);
     expect(queryObj).toEqual({
       where: {
@@ -102,8 +110,10 @@ describe('where', () => {
   });
 
   it('should add the query param to the base where object on a nested where if filterType is null, and ignore options', () => {
-    const middleware = formatters.where(null, {
-      someOption: 'ignoreMe',
+    const middleware = formatters.where({
+      filterOptions: {
+        someOption: 'ignoreMe',
+      },
     });
     middleware(queryObj, 'one.two', 'value', options);
     expect(queryObj).toEqual({
@@ -116,12 +126,11 @@ describe('where', () => {
   });
 
   it('should be able to change query output table column with formatterOptions.tableColName parameter', () => {
-    const middleware = formatters.where(
-      'includes',
-      { mode: 'insensitive' },
-      (v) => v,
-      { tableColName: 'one.two.three' },
-    );
+    const middleware = formatters.where({
+      filterType: 'includes',
+      filterOptions: { mode: 'insensitive' },
+      formatterOptions: { tableColName: 'one.two.three' },
+    });
 
     middleware(queryObj, 'ignored.path', 'myNestedValue', options);
     expect(queryObj).toEqual({
@@ -139,7 +148,7 @@ describe('where', () => {
   });
 
   it('should work with different path separators passed in the formatterOptions', () => {
-    const middleware = formatters.where(null, {}, (v) => v);
+    const middleware = formatters.where();
 
     middleware(queryObj, 'one/two/three', 'myNestedValue', {
       pathSeparator: '/',

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -163,6 +163,30 @@ describe('where', () => {
       },
     });
   });
+
+  it('should be able to group multiple filter types for the same table column', () => {
+    const fromDate = formatters.where({
+      filterType: 'gte',
+      formatterOptions: { tableColName: 'publishedAt' },
+      valueProcessor: (v) => new Date(v),
+    });
+    const toDate = formatters.where({
+      filterType: 'lte',
+      formatterOptions: { tableColName: 'publishedAt' },
+      valueProcessor: (v) => new Date(v),
+    });
+
+    fromDate(queryObj, 'fromDate', '1992-01-01', options);
+    toDate(queryObj, 'toDate', '1992-12-25', options);
+    expect(queryObj).toEqual({
+      where: {
+        publishedAt: {
+          gte: new Date('1992-01-01'),
+          lte: new Date('1992-12-25'),
+        },
+      },
+    });
+  });
 });
 
 describe('groupWhere', () => {

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -129,7 +129,7 @@ describe('where', () => {
     const middleware = formatters.where({
       filterType: 'includes',
       filterOptions: { mode: 'insensitive' },
-      formatterOptions: { tableColName: 'one.two.three' },
+      tableColName: 'one.two.three',
     });
 
     middleware(queryObj, 'ignored.path', 'myNestedValue', options);
@@ -167,12 +167,12 @@ describe('where', () => {
   it('should be able to group multiple filter types for the same table column', () => {
     const fromDate = formatters.where({
       filterType: 'gte',
-      formatterOptions: { tableColName: 'publishedAt' },
+      tableColName: 'publishedAt',
       valueProcessor: (v) => new Date(v),
     });
     const toDate = formatters.where({
       filterType: 'lte',
-      formatterOptions: { tableColName: 'publishedAt' },
+      tableColName: 'publishedAt',
       valueProcessor: (v) => new Date(v),
     });
 
@@ -191,16 +191,12 @@ describe('where', () => {
   it('should work with different path separators passed in the formatterOptions of a grouped query', () => {
     const lte = formatters.where({
       filterType: 'lte',
-      formatterOptions: {
-        tableColName: 'one/two/three/myTableColName',
-      },
+      tableColName: 'one/two/three/myTableColName',
     });
 
     const gte = formatters.where({
       filterType: 'gte',
-      formatterOptions: {
-        tableColName: 'one/two/three/myTableColName',
-      },
+      tableColName: 'one/two/three/myTableColName',
     });
 
     const newOptions = { pathSeparator: '/' };
@@ -268,7 +264,7 @@ describe('whereContains', () => {
   it('should overwrite default options with any other customsOption properties if provided', () => {
     const partialMatcher = formatters.whereContains({
       caseSensitive: false,
-      formatterOptions: { tableColName: 'name' },
+      tableColName: 'name',
       filterOptions: { myCustomThing: 'whatever' },
     });
     partialMatcher(queryObj, 'myKey', 'myValue', options);
@@ -285,7 +281,7 @@ describe('whereContains', () => {
 
   it('should work with nested paths', () => {
     const partialMatcher = formatters.whereContains({
-      formatterOptions: { tableColName: 'owner.name' },
+      tableColName: 'owner.name',
     });
     partialMatcher(queryObj, 'myKey', 'myValue', options);
     expect(queryObj).toEqual({

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -115,7 +115,7 @@ describe('where', () => {
     });
   });
 
-  it('should be able to change query output table column with formatterOptions.tableColName paramter', () => {
+  it('should be able to change query output table column with formatterOptions.tableColName parameter', () => {
     const middleware = formatters.where(
       'includes',
       { mode: 'insensitive' },

--- a/formatters.test.js
+++ b/formatters.test.js
@@ -187,96 +187,33 @@ describe('where', () => {
       },
     });
   });
-});
 
-describe('groupWhere', () => {
-  it('should allow user to group query params and output as a single object property', () => {
-    const fromDateMiddleware = formatters.groupWhere(
-      'dateRange',
-      'gte',
-      (value) => new Date(value),
-    );
-
-    const toDateMiddleware = formatters.groupWhere(
-      'dateRange',
-      'lte',
-      (value) => new Date(value),
-    );
-
-    fromDateMiddleware(queryObj, 'unusedKey', '2025-01-01', options);
-    toDateMiddleware(queryObj, 'unusedKey', '2025-12-31', options);
-    expect(queryObj).toEqual({
-      where: {
-        dateRange: {
-          gte: new Date('2025-01-01'),
-          lte: new Date('2025-12-31'),
-        },
+  it('should work with different path separators passed in the formatterOptions of a grouped query', () => {
+    const lte = formatters.where({
+      filterType: 'lte',
+      formatterOptions: {
+        tableColName: 'one/two/three/myTableColName',
       },
     });
-  });
 
-  it('should have a default valueFormatter function that just returns the value', () => {
-    const lte = formatters.groupWhere('count', 'lte');
-    const gte = formatters.groupWhere('count', 'gte');
-
-    lte(queryObj, 'unusedKey', 97, options);
-    gte(queryObj, 'unusedKey', 7, options);
-    expect(queryObj).toEqual({
-      where: {
-        count: {
-          lte: 97,
-          gte: 7,
-        },
+    const gte = formatters.where({
+      filterType: 'gte',
+      formatterOptions: {
+        tableColName: 'one/two/three/myTableColName',
       },
     });
-  });
 
-  it('should create a correctly nested object for creating a groupWhere for the table column of a foreign relation', () => {
-    const fromDateMiddleware = formatters.groupWhere(
-      'user.blogs.createdAt',
-      'gte',
-      (value) => new Date(value),
-    );
-
-    const toDateMiddleware = formatters.groupWhere(
-      'user.blogs.createdAt',
-      'lte',
-      (value) => new Date(value),
-    );
-
-    fromDateMiddleware(queryObj, 'unusedKey', '2025-01-01', options);
-    toDateMiddleware(queryObj, 'unusedKey', '2025-12-31', options);
-    expect(queryObj).toEqual({
-      where: {
-        user: {
-          blogs: {
-            createdAt: {
-              gte: new Date('2025-01-01'),
-              lte: new Date('2025-12-31'),
-            },
-          },
-        },
-      },
-    });
-  });
-
-  it('should work with different path separators passed in the formatterOptions', () => {
-    const middleware = formatters.groupWhere(
-      'one/two/three/myTableColName',
-      'lte',
-      (v) => v,
-    );
-
-    middleware(queryObj, 'lte', 'myLteValue', {
-      pathSeparator: '/',
-    });
+    const newOptions = { pathSeparator: '/' };
+    lte(queryObj, 'to', '9999', newOptions);
+    gte(queryObj, 'from', '-9999', newOptions);
     expect(queryObj).toEqual({
       where: {
         one: {
           two: {
             three: {
               myTableColName: {
-                lte: 'myLteValue',
+                gte: '-9999',
+                lte: '9999',
               },
             },
           },

--- a/index.js
+++ b/index.js
@@ -3,14 +3,11 @@ const formatters = require('./formatters');
 const processors = require('./processors');
 
 const defaultOptions = {
+  querySource: 'query',
   pathSeparator: '.',
 };
 
-function urlQueryToPrisma(
-  querySource = 'query',
-  customFormatter = {},
-  customOptions = {},
-) {
+function urlQueryToPrisma(customFormatter = {}, customOptions = {}) {
   const options = {
     ...defaultOptions,
     ...customOptions,
@@ -24,7 +21,7 @@ function urlQueryToPrisma(
 
   return (req, res, next) => {
     req.prismaQueryParams = { temp: {} };
-    const query = req[querySource];
+    const query = req[options.querySource];
 
     formatter.setup(req.prismaQueryParams);
 

--- a/index.test.js
+++ b/index.test.js
@@ -53,7 +53,7 @@ describe('urlQueryToPrisma', () => {
         mentalAge: '17',
       },
     });
-    const middleware = urlQueryToPrisma('query', {
+    const middleware = urlQueryToPrisma({
       age: (obj, key, value) => {
         obj.where = {
           ...obj.where,
@@ -81,7 +81,7 @@ describe('urlQueryToPrisma', () => {
         myParam: 'bilbo',
       },
     });
-    const middleware = urlQueryToPrisma('query', {
+    const middleware = urlQueryToPrisma({
       myParam: (obj, key, value) => {
         obj.where = {
           ...obj.where,
@@ -107,7 +107,7 @@ describe('urlQueryToPrisma', () => {
         stuff: '97',
       },
     });
-    const middleware = urlQueryToPrisma('query', {
+    const middleware = urlQueryToPrisma({
       setup: (obj) => {
         obj.someProperty = 'Added in setup function';
       },
@@ -139,20 +139,25 @@ describe('urlQueryToPrisma', () => {
       },
     });
 
-    const middleware = urlQueryToPrisma('body', {
-      myParam: (obj, key, value) => {
-        obj.where = {
-          ...obj.where,
-          myParam: Number(value),
-        };
+    const middleware = urlQueryToPrisma(
+      {
+        myParam: (obj, key, value) => {
+          obj.where = {
+            ...obj.where,
+            myParam: Number(value),
+          };
+        },
+        myDate: (obj, key, value) => {
+          obj.where = {
+            ...obj.where,
+            myDate: new Date(value),
+          };
+        },
       },
-      myDate: (obj, key, value) => {
-        obj.where = {
-          ...obj.where,
-          myDate: new Date(value),
-        };
+      {
+        querySource: 'body',
       },
-    });
+    );
 
     middleware(req, res, next);
     expect(req.prismaQueryParams).toEqual({
@@ -165,12 +170,12 @@ describe('urlQueryToPrisma', () => {
 
   it('should remove the temp property from the final prismaQueryParams object', () => {
     const req = httpMocks.createRequest({
-      body: {
+      query: {
         orderBy: 'someColumn',
       },
     });
 
-    const middleware = urlQueryToPrisma('body', {
+    const middleware = urlQueryToPrisma({
       orderBy: (obj, key, value) => {
         obj.where = {
           ...obj.where,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-query-to-prisma",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Express middleware to turn a url query into a formatted object suitable for inclusion in a Prisma ORM client query",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Anything using version 1 will have to be updated.

- ```groupWhere``` no longer exists. The same functionality can now be accomplished with the ```where``` formatter function since the ```tableColName``` parameter has been introduced.
- instead of up to 4 parameters having to be passed to the where formatter function even if you wanted to just change the 3rd or 4th one, it takes a single parameter of type object, which the user can change any or none of the properties. In short, the user can set whatever parameter they want without having to set any they don't.
- ```whereIncludes``` is a new function that wraps around ```where```, and is just to streamline case-insensitive partial string matches, since that is one of the most common types of queries.