### PR TITLE
Fix orderBy and sortOrder which would give prisma errors in certain situations

### DIFF
--- a/defaultFormatter.js
+++ b/defaultFormatter.js
@@ -29,10 +29,9 @@ const defaultFormatter = {
       );
       orderByPaths.push(path);
     }
-    // Turn orderBy object into an array of objects, representing each sub-object, but only the first layer.
-    const orderByArray = objToArray(orderBy);
-    queryObj.orderBy = orderByArray;
-    // Save paths so object structure can be re-created by sortOrder if it is used.
+    // Prisma expects an array for orderBy.
+    queryObj.orderBy = objToArray(orderBy);
+    // Save paths so object structure can be re-created by sortOrder if that query param is used.
     queryObj.temp.orderByPaths = orderByPaths;
   },
   sortOrder: (queryObj, key, value, options) => {
@@ -59,11 +58,11 @@ const defaultFormatter = {
       }
     }
     // Use mergeArraysInPlace to merge into existing orderBy array on queryObj.
-    const orderByArray = objToArray(updatedOrderBy);
+    const updatedOrderByArray = objToArray(updatedOrderBy);
     const discardOldValue = (x, y) => y;
     queryObj.orderBy = mergeArraysInPlace(
       queryObj.orderBy,
-      orderByArray,
+      updatedOrderByArray,
       // Use deepMerge on each pair of elements to allow nested objects, fields, etc.
       (a, b) => deepMerge(a, b, discardOldValue),
     );

--- a/defaultFormatter.js
+++ b/defaultFormatter.js
@@ -1,5 +1,12 @@
 const deepMerge = require('@rubicon2/deep-merge');
 const pathToNestedObj = require('path-to-nested-obj');
+const mergeArraysInPlace = require('merge-arrays-in-place');
+
+function objToArray(obj) {
+  return Object.entries(obj).map(([key, value]) => {
+    return { [key]: value };
+  });
+}
 
 // Basically, the properties on the formatter should correspond to params in the url query string.
 // So if you have url.com?take=5&skip=10, the take function will be called with a value of 5,
@@ -9,50 +16,57 @@ const defaultFormatter = {
   skip: (queryObj, key, value) => (queryObj.skip = Number(value)),
   cursor: (queryObj, key, value) => (queryObj.cursor = { id: Number(value) }),
   orderBy: (queryObj, key, value, options) => {
-    // Works with string and arrays of strings, and paths like you would use with sql, e.g. owner.name.
-    if (Array.isArray(value)) {
-      queryObj.orderBy = {};
-      value.forEach((e) => {
-        queryObj.orderBy = deepMerge(
-          queryObj.orderBy,
-          pathToNestedObj(e, options.pathSeparator, 'asc'),
-        );
-        // Save keys to an array for use in sortOrder later. In sortOrder function,
-        // an updated version of the orderBy obj value will be constructed out of the
-        // saved paths, and assigned the updated value.
-        const orderByPaths = queryObj.temp.orderByPaths;
-        queryObj.temp.orderByPaths = orderByPaths ? [...orderByPaths, e] : [e];
-      });
-    } else {
-      queryObj.orderBy = pathToNestedObj(value, options.pathSeparator, 'asc');
-      queryObj.temp.orderByPaths = [value];
+    // Throw it into an array even if there is only one value. Makes everything simpler.
+    const orderByValues = Array.isArray(value) ? value : [value];
+    const orderByPaths = [];
+    // Need to do as an object to allow deep merging, turn into an array later for prisma use.
+    let orderBy = {};
+    for (const path of orderByValues) {
+      const existingSort = queryObj?.temp?.sortOrder?.shift();
+      orderBy = deepMerge(
+        orderBy,
+        pathToNestedObj(path, options.pathSeparator, existingSort || 'asc'),
+      );
+      orderByPaths.push(path);
     }
+    // Turn orderBy object into an array of objects, representing each sub-object, but only the first layer.
+    const orderByArray = objToArray(orderBy);
+    queryObj.orderBy = orderByArray;
+    // Save paths so object structure can be re-created by sortOrder if it is used.
+    queryObj.temp.orderByPaths = orderByPaths;
   },
   sortOrder: (queryObj, key, value, options) => {
-    // Works with string and arrays of strings.
-    // Assumes the first key in orderByKeys corresponds to the first value in sortOrder.
-    const orderByPaths = queryObj.temp.orderByPaths;
-    if (Array.isArray(value)) {
-      value.forEach((e) => {
-        const savedPath = orderByPaths?.shift();
-        if (savedPath) {
-          const mega = pathToNestedObj(savedPath, options.pathSeparator, e);
-          queryObj.orderBy = {
-            ...queryObj.orderBy,
-            ...mega,
-          };
-        }
-      });
-    } else {
-      const savedPath = orderByPaths?.shift();
-      if (savedPath) {
-        const obj = pathToNestedObj(savedPath, options.pathSeparator, value);
-        queryObj.orderBy = {
-          ...queryObj.orderBy,
-          ...obj,
-        };
+    // If sortOrder runs before orderBy, just store the values for orderBy to use.
+    if (!queryObj.temp.orderByPaths) {
+      queryObj.temp.sortOrder = [value].flat();
+      return;
+    }
+    const sortValues = Array.isArray(value) ? value : [value];
+    // Use stored paths to create new object with new sortOrder values.
+    let updatedOrderBy = {};
+    for (let i = 0; i < sortValues.length; i++) {
+      const currentPath = queryObj.temp.orderByPaths[i];
+      const currentValue = sortValues[i];
+      if (currentPath) {
+        updatedOrderBy = deepMerge(
+          updatedOrderBy,
+          pathToNestedObj(currentPath, options.pathSeparator, currentValue),
+        );
+      } else {
+        // If we have run out of orderByPaths, that means we have a sortOrder value and no more paths to match to.
+        // No point continuing the loop, so break out.
+        break;
       }
     }
+    // Use mergeArraysInPlace to merge into existing orderBy array on queryObj.
+    const orderByArray = objToArray(updatedOrderBy);
+    const discardOldValue = (x, y) => y;
+    queryObj.orderBy = mergeArraysInPlace(
+      queryObj.orderBy,
+      orderByArray,
+      // Use deepMerge on each pair of elements to allow nested objects, fields, etc.
+      (a, b) => deepMerge(a, b, discardOldValue),
+    );
   },
   setup: () => {
     // For setup user may want to do in prep for their custom formatter functions.

--- a/defaultFormatter.test.js
+++ b/defaultFormatter.test.js
@@ -18,70 +18,308 @@ beforeEach(() => {
 });
 
 describe('defaultFormatter', () => {
-  it('should add a skip property and value of type Number if present in url', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        skip: '5',
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams.skip).toBe(5);
-    expect(typeof req.prismaQueryParams.skip).toBe('number');
-  });
-
-  it('should add a take property and value of type Number if present in url', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        take: '3',
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams.take).toBe(3);
-    expect(typeof req.prismaQueryParams.take).toBe('number');
-  });
-
-  it('should add a cursor property which is of type object which contains property id', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        cursor: '97',
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams.cursor).toEqual({
-      id: 97,
+  describe('skip property', () => {
+    it('should add a skip property and value of type Number if present in url', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          skip: '5',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.skip).toBe(5);
+      expect(typeof req.prismaQueryParams.skip).toBe('number');
     });
   });
 
-  it('should add a orderBy property and value of type object if present in url', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: 'name',
-      },
+  describe('take property', () => {
+    it('should add a take property and value of type Number if present in url', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          take: '3',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.take).toBe(3);
+      expect(typeof req.prismaQueryParams.take).toBe('number');
     });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams.orderBy).toEqual({ name: 'asc' });
-    expect(typeof req.prismaQueryParams.orderBy).toBe('object');
   });
 
-  it('should set orderBy property value to that of sortOrder if present in url', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: 'name',
-        sortOrder: 'desc',
-      },
+  describe('cursor property', () => {
+    it('should add a cursor property which is of type object which contains property id', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          cursor: '97',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.cursor).toEqual({
+        id: 97,
+      });
     });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams.orderBy).toEqual({ name: 'desc' });
+  });
+
+  describe('orderBy property', () => {
+    it('should add a orderBy property and value of type array if present in url', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: 'name',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(Array.isArray(req.prismaQueryParams.orderBy)).toBe(true);
+      expect(req.prismaQueryParams.orderBy).toEqual([{ name: 'asc' }]);
+    });
+
+    it('should be able to use an array of orderBy properties if present in url', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: ['name', 'email'],
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        { name: 'asc' },
+        { email: 'asc' },
+      ]);
+      expect(typeof req.prismaQueryParams.orderBy).toBe('object');
+    });
+
+    it('should be able to sort by nested object value when given a path separated by dots', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: 'owner.name',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        {
+          owner: {
+            name: 'asc',
+          },
+        },
+      ]);
+    });
+
+    it('should be able to sort by multiple nested object values when given paths separated by dots', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: ['publishedAt', 'owner.name', 'owner.email'],
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        { publishedAt: 'asc' },
+        {
+          owner: {
+            name: 'asc',
+            email: 'asc',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('orderBy and sortOrder properties together', () => {
+    it('should set orderBy property value to that of sortOrder if present in url', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: 'name',
+          sortOrder: 'desc',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([{ name: 'desc' }]);
+    });
+
+    it('should work with multiple orderBy and sortOrder params', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: ['author', 'publishedDate'],
+          sortOrder: ['desc', 'asc'],
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        { author: 'desc' },
+        { publishedDate: 'asc' },
+      ]);
+    });
+
+    it('should not break if there are more orderBy params than sortOrder params', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: ['author', 'publishedDate'],
+          sortOrder: 'desc',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        { author: 'desc' },
+        { publishedDate: 'asc' },
+      ]);
+    });
+
+    it('should not break if there are less orderBy params than sortOrder params', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: 'author',
+          sortOrder: ['desc', 'desc'],
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        {
+          author: 'desc',
+        },
+      ]);
+    });
+
+    it('should not break if there is a sortOrder param with no orderBy params', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          sortOrder: 'desc',
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams).toEqual({});
+    });
+
+    it('should not break if there is a sortOrder params array with no orderBy params', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          sortOrder: ['desc', 'desc'],
+        },
+      });
+      const middleware = urlQueryToPrisma();
+      middleware(req, res, next);
+      expect(req.prismaQueryParams).toEqual({});
+    });
+
+    it.each([
+      {
+        query: {
+          orderBy: ['publishedAt', 'owner.name'],
+          sortOrder: ['asc', 'desc'],
+        },
+        result: [
+          { publishedAt: 'asc' },
+          {
+            owner: {
+              name: 'desc',
+            },
+          },
+        ],
+      },
+      {
+        query: {
+          orderBy: ['publishedAt', 'owner.name', 'owner.email'],
+          sortOrder: ['desc', 'asc', 'desc'],
+        },
+        result: [
+          { publishedAt: 'desc' },
+          {
+            owner: {
+              name: 'asc',
+              email: 'desc',
+            },
+          },
+        ],
+      },
+    ])(
+      'should be able to correctly match orderBy dot paths and sortOrder query params',
+      ({ query, result }) => {
+        const req = httpMocks.createRequest({
+          ...basicRequest,
+          query,
+        });
+        const middleware = urlQueryToPrisma();
+        middleware(req, res, next);
+        expect(req.prismaQueryParams.orderBy).toEqual(result);
+      },
+    );
+
+    it('orderBy and sortOrder should use the path separator on the options', () => {
+      const req = httpMocks.createRequest({
+        ...basicRequest,
+        query: {
+          orderBy: ['owner/name', 'publishedAt'],
+          sortOrder: ['desc', 'asc'],
+        },
+      });
+      const middleware = urlQueryToPrisma({}, { pathSeparator: '/' });
+      middleware(req, res, next);
+      expect(req.prismaQueryParams.orderBy).toEqual([
+        {
+          owner: {
+            name: 'desc',
+          },
+        },
+        {
+          publishedAt: 'asc',
+        },
+      ]);
+    });
+
+    it.each([
+      {
+        query: {
+          orderBy: 'publishedDate',
+          sortOrder: 'desc',
+        },
+        result: [
+          {
+            publishedDate: 'desc',
+          },
+        ],
+      },
+      {
+        query: {
+          sortOrder: 'desc',
+          orderBy: 'publishedDate',
+        },
+        result: [
+          {
+            publishedDate: 'desc',
+          },
+        ],
+      },
+    ])(
+      'should work no matter what order the functions run in',
+      ({ query, result }) => {
+        const req = httpMocks.createRequest({
+          ...basicRequest,
+          query,
+        });
+        const middleware = urlQueryToPrisma({}, { pathSeparator: '.' });
+        middleware(req, res, next);
+        expect(req.prismaQueryParams.orderBy).toEqual(result);
+      },
+    );
   });
 
   it('should produce a coherent query object with take, skip, orderBy and where objects in a prisma-friendly format', () => {
@@ -107,169 +345,14 @@ describe('defaultFormatter', () => {
     expect(req.prismaQueryParams).toEqual({
       skip: 5,
       take: 10,
-      orderBy: {
-        publishedDate: 'desc',
-      },
+      orderBy: [
+        {
+          publishedDate: 'desc',
+        },
+      ],
       where: {
         author: 'billy',
       },
-    });
-  });
-
-  it('should work with multiple orderBy and sortOrder params', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: ['author', 'publishedDate'],
-        sortOrder: ['desc', 'asc'],
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: [{ author: 'desc' }, { publishedDate: 'asc' }],
-    });
-  });
-
-  it('should not break if there are more orderBy params than sortOrder params', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: ['author', 'publishedDate'],
-        sortOrder: 'desc',
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: [{ author: 'desc' }, { publishedDate: 'asc' }],
-    });
-  });
-
-  it('should not break if there are less orderBy params than sortOrder params', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: ['author'],
-        sortOrder: ['desc', 'desc'],
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        author: 'desc',
-      },
-    });
-  });
-
-  it('should not break if there is a sortOrder param with no orderBy params', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        sortOrder: 'desc',
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({});
-  });
-
-  it('should not break if there is a sortOrder params array with no orderBy params', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        sortOrder: ['desc', 'desc'],
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({});
-  });
-
-  it('should be able to sort by nested object values when given a path separated by dots', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: 'owner.name',
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        owner: {
-          name: 'asc',
-        },
-      },
-    });
-  });
-
-  it('should be able to sort by multiple nested object values when given paths separated by dots', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: ['publishedAt', 'owner.name', 'owner.email'],
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: [
-        { publishedAt: 'asc' },
-        {
-          owner: {
-            name: 'asc',
-            email: 'asc',
-          },
-        },
-      ],
-    });
-  });
-
-  it('should be able correctly match orderBy dot paths and sortOrder query params', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: ['publishedAt', 'owner.name'],
-        sortOrder: ['asc', 'desc'],
-      },
-    });
-    const middleware = urlQueryToPrisma();
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: [
-        { publishedAt: 'asc' },
-        {
-          owner: {
-            name: 'desc',
-          },
-        },
-      ],
-    });
-  });
-
-  it('orderBy and sortOrder should use the path separator on the options', () => {
-    const req = httpMocks.createRequest({
-      ...basicRequest,
-      query: {
-        orderBy: ['owner/name', 'publishedAt'],
-        sortOrder: ['desc', 'asc'],
-      },
-    });
-    const middleware = urlQueryToPrisma({}, { pathSeparator: '/' });
-    middleware(req, res, next);
-    expect(req.prismaQueryParams).toEqual({
-      orderBy: [
-        {
-          owner: {
-            name: 'desc',
-          },
-        },
-        {
-          publishedAt: 'asc',
-        },
-      ],
     });
   });
 });

--- a/defaultFormatter.test.js
+++ b/defaultFormatter.test.js
@@ -71,7 +71,7 @@ describe('defaultFormatter', () => {
     expect(typeof req.prismaQueryParams.orderBy).toBe('object');
   });
 
-  it('should set orderBy[fieldName] property value to that of sortOrder if present in url', () => {
+  it('should set orderBy property value to that of sortOrder if present in url', () => {
     const req = httpMocks.createRequest({
       ...basicRequest,
       query: {
@@ -127,10 +127,7 @@ describe('defaultFormatter', () => {
     const middleware = urlQueryToPrisma();
     middleware(req, res, next);
     expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        author: 'desc',
-        publishedDate: 'asc',
-      },
+      orderBy: [{ author: 'desc' }, { publishedDate: 'asc' }],
     });
   });
 
@@ -145,10 +142,7 @@ describe('defaultFormatter', () => {
     const middleware = urlQueryToPrisma();
     middleware(req, res, next);
     expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        author: 'desc',
-        publishedDate: 'asc',
-      },
+      orderBy: [{ author: 'desc' }, { publishedDate: 'asc' }],
     });
   });
 
@@ -221,13 +215,15 @@ describe('defaultFormatter', () => {
     const middleware = urlQueryToPrisma();
     middleware(req, res, next);
     expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        publishedAt: 'asc',
-        owner: {
-          name: 'asc',
-          email: 'asc',
+      orderBy: [
+        { publishedAt: 'asc' },
+        {
+          owner: {
+            name: 'asc',
+            email: 'asc',
+          },
         },
-      },
+      ],
     });
   });
 
@@ -242,12 +238,14 @@ describe('defaultFormatter', () => {
     const middleware = urlQueryToPrisma();
     middleware(req, res, next);
     expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        publishedAt: 'asc',
-        owner: {
-          name: 'desc',
+      orderBy: [
+        { publishedAt: 'asc' },
+        {
+          owner: {
+            name: 'desc',
+          },
         },
-      },
+      ],
     });
   });
 
@@ -262,12 +260,16 @@ describe('defaultFormatter', () => {
     const middleware = urlQueryToPrisma({}, { pathSeparator: '/' });
     middleware(req, res, next);
     expect(req.prismaQueryParams).toEqual({
-      orderBy: {
-        owner: {
-          name: 'desc',
+      orderBy: [
+        {
+          owner: {
+            name: 'desc',
+          },
         },
-        publishedAt: 'asc',
-      },
+        {
+          publishedAt: 'asc',
+        },
+      ],
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@rubicon2/deep-merge": "^1.1.0",
+        "merge-arrays-in-place": "^1.0.0",
         "path-to-nested-obj": "^1.0.0"
       },
       "devDependencies": {
@@ -20,6 +21,20 @@
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "node-mocks-http": "^1.16.2",
+        "prettier": "^3.5.3"
+      }
+    },
+    "../merge-arrays-in-place": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "GPL-3.0",
+      "devDependencies": {
+        "@eslint/js": "^9.29.0",
+        "eslint": "^9.29.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-jest": "^29.0.1",
+        "globals": "^16.2.0",
+        "jest": "^30.0.2",
         "prettier": "^3.5.3"
       }
     },
@@ -3884,6 +3899,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/merge-arrays-in-place": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-arrays-in-place/-/merge-arrays-in-place-1.0.0.tgz",
+      "integrity": "sha512-W3dnogTLw9OYNXxvDVKK/uWUdXwgzvby8s1mNafJgd1/LVI2Utyg3LFPOlwadMC4pcF9n6kuTp4UU574yc/Wpg==",
+      "license": "GPL-3.0"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "url-query-to-prisma",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "url-query-to-prisma",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@rubicon2/deep-merge": "^1.0.1",
+        "@rubicon2/deep-merge": "^1.1.0",
         "path-to-nested-obj": "^1.0.0"
       },
       "devDependencies": {
@@ -20,21 +20,6 @@
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "node-mocks-http": "^1.16.2",
-        "prettier": "^3.5.3"
-      }
-    },
-    "../deep-merge": {
-      "name": "@rubicon2/deep-merge",
-      "version": "1.0.1",
-      "extraneous": true,
-      "license": "GPL-3.0",
-      "devDependencies": {
-        "@eslint/js": "^9.28.0",
-        "eslint": "^9.28.0",
-        "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-jest": "^28.13.5",
-        "globals": "^16.2.0",
-        "jest": "^30.0.0",
         "prettier": "^3.5.3"
       }
     },
@@ -53,24 +38,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -78,22 +63,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
+      "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.10",
-        "@babel/helper-compilation-targets": "^7.26.5",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.10",
-        "@babel/types": "^7.26.10",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.4",
+        "@babel/parser": "^7.27.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.27.4",
+        "@babel/types": "^7.27.3",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -108,15 +93,25 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/parser": "^7.27.5",
+        "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -126,14 +121,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.8",
-        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -142,30 +137,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -175,9 +180,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -185,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -195,9 +200,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -205,9 +210,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -215,27 +220,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -300,13 +305,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -342,13 +347,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -468,13 +473,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -484,32 +489,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -528,14 +533,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -549,9 +554,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
-      "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -591,9 +596,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -606,9 +611,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -616,9 +621,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -666,13 +671,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
-      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -686,14 +694,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
+      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.15.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -752,9 +773,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1266,9 +1287,9 @@
       }
     },
     "node_modules/@rubicon2/deep-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rubicon2/deep-merge/-/deep-merge-1.0.1.tgz",
-      "integrity": "sha512-sOAhYp7awweZcvhcaTZGpC/jhXgRDXGMcE58V6Lm3vg5t7CUsR0nWhcVN2Vbwi8ZudZLCwWIiuJhRlImD3e6pw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rubicon2/deep-merge/-/deep-merge-1.1.0.tgz",
+      "integrity": "sha512-7GYVPY9NiZqnV8gkZkDkdY3pPkAuMTBGCkeVeBXKT2ke+Sa49N+U7a6oLKACsGMT34iabFNQYVdfibe1iZ6RJQ==",
       "license": "GPL-3.0"
     },
     "node_modules/@sinclair/typebox": {
@@ -1344,9 +1365,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1395,13 +1416,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1428,15 +1449,37 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz",
-      "integrity": "sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
+      "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0"
+        "@typescript-eslint/tsconfig-utils": "^8.34.1",
+        "@typescript-eslint/types": "^8.34.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
+      "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1446,10 +1489,27 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
+      "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.0.tgz",
-      "integrity": "sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
+      "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1461,20 +1521,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz",
-      "integrity": "sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
+      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/visitor-keys": "8.31.0",
+        "@typescript-eslint/project-service": "8.34.1",
+        "@typescript-eslint/tsconfig-utils": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1488,9 +1550,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1513,30 +1575,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.0.tgz",
-      "integrity": "sha512-qi6uPLt9cjTFxAb1zGNgTob4x9ur7xC6mHQJ8GwEzGMGE9tYniublmJaowOJ9V2jUzxrltTPfdG2nKlWsq0+Ww==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
+      "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.31.0",
-        "@typescript-eslint/types": "8.31.0",
-        "@typescript-eslint/typescript-estree": "8.31.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.34.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1551,14 +1600,14 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz",
-      "integrity": "sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
+      "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.31.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.34.1",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1583,9 +1632,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1741,6 +1790,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
@@ -1809,9 +1868,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1833,9 +1892,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
+      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "dev": true,
       "funding": [
         {
@@ -1853,10 +1912,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
+        "caniuse-lite": "^1.0.30001718",
+        "electron-to-chromium": "^1.5.160",
         "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1903,9 +1962,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001715",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
-      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
+      "version": "1.0.30001723",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
+      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
       "dev": true,
       "funding": [
         {
@@ -2091,9 +2150,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2109,9 +2168,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2171,9 +2230,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.140",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.140.tgz",
-      "integrity": "sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q==",
+      "version": "1.5.170",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.170.tgz",
+      "integrity": "sha512-GP+M7aeluQo9uAyiTCxgIj/j+PrWhMlY7LFVj8prlsPljd0Fdg9AprlfUi+OCSFWy9Y5/2D/Jrj9HS8Z4rpKWA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2231,20 +2290,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.25.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
-      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-array": "^0.20.1",
         "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.25.1",
-        "@eslint/plugin-kit": "^0.2.8",
+        "@eslint/js": "9.29.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2255,9 +2314,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2292,22 +2351,25 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
-      "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
-      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
+      "version": "28.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
+      "integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2331,9 +2393,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2348,9 +2410,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2361,15 +2423,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2744,9 +2806,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2997,19 +3059,6 @@
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -3541,19 +3590,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -3829,19 +3865,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -4004,9 +4027,9 @@
       "license": "MIT"
     },
     "node_modules/node-mocks-http": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.16.2.tgz",
-      "integrity": "sha512-2Sh6YItRp1oqewZNlck3LaFp5vbyW2u51HX2p1VLxQ9U/bG90XV8JY9O7Nk+HDd6OOn/oV3nA5Tx5k4Rki0qlg==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.17.2.tgz",
+      "integrity": "sha512-HVxSnjNzE9NzoWMx9T9z4MLqwMpLwVvA0oVZ+L+gXskYXEJ6tFn3Kx4LargoB6ie7ZlCLplv7QbWO6N+MysWGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4601,13 +4624,16 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -4923,9 +4949,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier": "^3.5.3"
   },
   "dependencies": {
-    "@rubicon2/deep-merge": "^1.0.1",
+    "@rubicon2/deep-merge": "^1.1.0",
     "path-to-nested-obj": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@rubicon2/deep-merge": "^1.1.0",
+    "merge-arrays-in-place": "^1.0.0",
     "path-to-nested-obj": "^1.0.0"
   }
 }


### PR DESCRIPTION
The orderBy and sortOrder functions on the default formatter were giving the incorrect output. 

Prisma expects an array for multiple orderBy fields, but these functions were producing an object with keys for each field.

Also these functions would not work if sortOrder was called first. This has also been fixed.